### PR TITLE
Parsing improvement

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -29,9 +29,9 @@ stdout = "/tmp/nginx.stdout" # /tmp/{name}.stdout
 stderr = "/tmp/nginx.stderr" # /tmp/{name}.stderr
 # env variable we should give to the task
 env = [
-	"STARTED_BY=taskmaster",
-	"ANSWER=42",
-] # None
+	{ key = "STARTED_BY", value = "taskmaster" },
+	{ key = "ANSWER", value = "42" }
+ ] # None
 
 [[tasks]]
 name = "vogsphere"

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,10 +103,16 @@ struct LitteralTasks {
 impl LitteralTasks {
 	fn parse(self) -> TaskConf {
 		let cmds = parse_cmd(&self.cmd);
-		let name: String = self.name.unwrap_or(cmds[0].clone());
+		let binary: String = cmds[0].clone();
+		let args: Vec<String> = cmds.into_iter().skip(1).collect();
+		let args = if args.len() == 0 { None } else { Some(args)};
+		let name = self.name.unwrap_or(binary.clone());
+		let stdout = PathBuf::from(self.stdout.unwrap_or(format!("/tmp/{}.stdout", name)));
+		let stderr =  PathBuf::from(self.stderr.unwrap_or(format!("/tmp/{}.stderr", name)));
 		TaskConf {
-			binary: cmds[0].to_string(),
-			args: cmds.iter().skip(1).map(|e| e.to_string()).collect(),
+			name,
+			binary,
+			args,
 			numproc: self.numproc,
 			umask: self.umask,
 			workingdir: self.workingdir.as_ref().and_then(|e| Some(PathBuf::from(e))),
@@ -117,10 +123,9 @@ impl LitteralTasks {
 			startime: self.startime,
 			stopsignal: 9, // TODO: parse str into u32 or signal enum
 			stoptime: self.stoptime,
-			stdout: PathBuf::from(self.stdout.unwrap_or(format!("/tmp/{}.stdout", name))),
-			stderr: PathBuf::from(self.stderr.unwrap_or(format!("/tmp/{}.stderr", name))),
+			stdout,
+			stderr,
 			env: to_vec(self.env).into_iter().map(make_env).collect(),
-			name: name
 		}
 	}
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,9 +102,8 @@ struct LitteralTasks {
 
 impl LitteralTasks {
 	fn parse(self) -> TaskConf {
-		let cmds = parse_cmd(&self.cmd);
-		let binary: String = cmds[0].clone();
-		let args: Vec<String> = cmds.into_iter().skip(1).collect();
+		let args = parse_cmd(&self.cmd);
+		let binary: String = args[0].clone();
 		let args = if args.len() == 0 { None } else { Some(args)};
 		let name = self.name.unwrap_or(binary.clone());
 		let stdout = PathBuf::from(self.stdout.unwrap_or(format!("/tmp/{}.stdout", name)));

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,8 +44,10 @@ struct EnvVar {
 	value: String
 }
 
-fn make_env(src: EnvVar) -> ( String, String ) {
-	( src.key, src.value )
+impl EnvVar {
+	fn to_string(self) -> String {
+		format!("{}={}", self.key, self.value)
+	}
 }
 
 #[derive(Deserialize, Debug)]
@@ -124,7 +126,7 @@ impl LitteralTasks {
 			stoptime: self.stoptime,
 			stdout,
 			stderr,
-			env: to_vec(self.env).into_iter().map(make_env).collect(),
+			env: to_vec(self.env).into_iter().map(EnvVar::to_string).collect(),
 		}
 	}
 }
@@ -139,7 +141,7 @@ impl LitteralConf {
 	fn parse(self) -> Conf {
 		Conf {
 			port: self.port.unwrap_or(6060),
-			tasks: self.tasks.into_iter().map(|e| e.parse()).collect()
+			tasks: self.tasks.into_iter().map(LitteralTasks::parse).collect()
 		}
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ type Error = Box<dyn std::error::Error>;
 const CONFIGURATION: &str = "/home/tet/project/taskmaster/example.toml";
 
 fn main() -> Result<(), Error> {
-	let _config = Conf::new(CONFIGURATION.to_string())?;
-	println!("Hello, world!");
+	let config = Conf::new(CONFIGURATION.to_string())?;
+	dbg!(config);
 	Ok(())
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -29,7 +29,7 @@ impl Into<Autorestart> for String {
 pub struct TaskConf {
 	pub name: String,
 	pub binary: String,
-	pub args: Vec<String>,
+	pub args: Option<Vec<String>>,
 	pub numproc: u32,
 	pub umask: u32,
 	pub workingdir: Option<PathBuf>, // env::set_current_dir

--- a/src/task.rs
+++ b/src/task.rs
@@ -42,5 +42,5 @@ pub struct TaskConf {
 	pub stoptime: u32,
 	pub stdout: PathBuf,
 	pub stderr: PathBuf,
-	pub env: Vec<(String, String)>
+	pub env: Vec<String>
 }


### PR DESCRIPTION
# Fix #4 
Some parsing improvement:
 - __cmd__: Handle `'`, `"` and `\`,
 - __env__: Use a struct now to separate the key and the value instead of the `=` char

Generally improve the memory usage of the parsing: no more clone.