### PR TITLE
Handle sigchild, threadsafe interface

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,214 +1,35 @@
-use crate::task::TaskConf;
+use std::sync::Mutex;
+
+use crate::task::{ TaskConf, RunningTask };
 use crate::Error;
-use libc::c_char;
-use serde_derive::Deserialize;
-use std::convert::From;
-use std::fs;
-use std::path::PathBuf;
-
-fn parse_cmd(entry: &String) -> Vec<String> {
-	let mut res = vec![];
-	let mut actual_string = String::new();
-	let mut dquote = false;
-	let mut squote = false;
-	let mut bslash = false;
-	let mut space = false;
-
-	for c in entry.chars() {
-		match c {
-			x if x == '\\' && !squote && !bslash => bslash = true,
-			x if x == '\\' && !dquote && !squote && bslash => { bslash = false; actual_string.push('\\'); }
-			x if x == '\'' && !squote && !dquote && !bslash => squote = true,
-			x if x == '\'' && squote => squote = false,
-			x if x == '"' && dquote && !bslash => dquote = false,
-			x if x == '"' && !dquote && !bslash && !squote => dquote = true,
-			x if !x.is_whitespace() && space => { space = false; res.push(actual_string); actual_string = x.to_string(); }
-			x if x.is_whitespace() && !dquote && !squote && !bslash => space = true,
-			x if x.is_whitespace() && bslash => { bslash = false; actual_string.push(x); }
-			x if (x == '\'' || x == '"' || x == '\\') && bslash => { bslash = false; actual_string.push(c); }
-			_ => { space = false; actual_string.push(c); }
-		}
-	}
-	if !actual_string.is_empty() {
-		res.push(actual_string);
-	}
-
-	if dquote || squote || bslash {
-		// TODO: log or exit because invalid command
-	}
-	res
-}
-
-#[derive(Deserialize, Debug)]
-struct EnvVar {
-	key: String,
-	value: String,
-}
-
-impl EnvVar {
-	fn to_string(self) -> String {
-		format!("{}={}", self.key, self.value)
-	}
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
-enum MaybeArray<T> {
-	Alone(T),
-	Multiple(Vec<T>),
-}
-
-fn to_vec<T>(src: MaybeArray<T>) -> Vec<T> {
-	match src {
-		MaybeArray::Alone(n) => vec![n],
-		MaybeArray::Multiple(n) => n,
-	}
-}
-
-fn default_env() -> MaybeArray<EnvVar> { MaybeArray::Multiple(vec![]) }
-fn default_alone_zero() -> MaybeArray<i32> { MaybeArray::Alone(0) }
-fn default_autorestart() -> String { "false".to_string() }
-fn default_term() -> String { "TERM".to_string() }
-fn default_false() -> bool { false }
-fn default_umask() -> u32 { 777 }
-fn default_five() -> u32 { 5 }
-fn default_one() -> u32 { 1 }
-
-#[derive(Deserialize, Debug)]
-struct LitteralTasks {
-	cmd: String,
-	name: Option<String>,
-	#[serde(default = "default_one")]
-	numproc: u32,
-	#[serde(default = "default_umask")]
-	umask: u32,
-	workingdir: Option<String>,
-	#[serde(default = "default_false")]
-	autostart: bool,
-	#[serde(default = "default_autorestart")]
-	autorestart: String,
-	#[serde(default = "default_alone_zero")]
-	exitcodes: MaybeArray<i32>,
-	#[serde(default = "default_five")]
-	startretries: u32,
-	#[serde(default = "default_one")]
-	startime: u32,
-	#[serde(default = "default_term")]
-	stopsignal: String,
-	#[serde(default = "default_one")]
-	stoptime: u32,
-	stdout: Option<String>,
-	stderr: Option<String>,
-	#[serde(default = "default_env")]
-	env: MaybeArray<EnvVar>,
-}
-
-fn to_bytes(input: Vec<String>) -> Vec<Vec<c_char>> {
-	input
-		.into_iter()
-		.map(|e| {
-			let mut tmp = e.into_bytes();
-			tmp.push(b'\0');
-			tmp.iter().map(|b| *b as c_char).collect()
-		})
-		.collect()
-}
-
-impl LitteralTasks {
-	fn parse(self) -> TaskConf {
-		let handler = parse_cmd(&self.cmd);
-		let name = self.name.unwrap_or(handler[0].clone());
-		let args = to_bytes(handler);
-		let binary = args[0].clone();
-		let args = if args.len() == 0 { None } else { Some(args)};
-		let stdout = PathBuf::from(self.stdout.unwrap_or(format!("/tmp/{}.stdout", name)));
-		let stderr = PathBuf::from(self.stderr.unwrap_or(format!("/tmp/{}.stderr", name)));
-		TaskConf {
-			name,
-			binary,
-			args,
-			numproc: self.numproc,
-			umask: self.umask,
-			workingdir: self
-				.workingdir
-				.as_ref()
-				.and_then(|e| Some(PathBuf::from(e))),
-			autostart: self.autostart,
-			autorestart: self.autorestart.into(),
-			exitcodes: to_vec(self.exitcodes),
-			startretries: self.startretries,
-			startime: self.startime,
-			stopsignal: 9, // TODO: parse str into u32 or signal enum
-			stoptime: self.stoptime,
-			stdout,
-			stderr,
-			env: to_vec(self.env)
-				.into_iter()
-				.map(EnvVar::to_string)
-				.collect(),
-		}
-	}
-}
-
-#[derive(Deserialize, Debug)]
-struct LitteralConf {
-	port: Option<u32>,
-	tasks: Vec<LitteralTasks>,
-}
-
-impl LitteralConf {
-	fn parse(self) -> Conf {
-		Conf {
-			port: self.port.unwrap_or(6060),
-			tasks: self.tasks.into_iter().map(LitteralTasks::parse).collect(),
-		}
-	}
-}
+use crate::parser;
 
 #[derive(Debug)]
 pub struct Conf {
-	port: u32,
-	tasks: Vec<TaskConf>,
+	pub port: u32,
+	pub tasks: Mutex<Vec<TaskConf>>, // Mutex or RWlock ?
+	pub runnings: Mutex<Vec<RunningTask>>
 }
 
 impl Conf {
 	pub fn new(path: String) -> Result<Conf, Error> {
-		let file = fs::read_to_string(path)?;
-		let litteral_conf = toml::from_str::<LitteralConf>(&file)?;
-		let conf = litteral_conf.parse();
-		Ok(conf)
+		parser::parse_config(path)
 	}
 
 	pub fn autostart(&self) {
-		for task in self.tasks.iter() {
+		let tasks = self.tasks.lock().unwrap();
+		let mut runnings = self.runnings.lock().unwrap();
+		for task in tasks.iter() {
 			if task.autostart == true {
-				task.run();
+				let pid = task.run(); // TODO: handle errors
+				runnings.push(RunningTask::new(&task.name, &task.name, pid));
 			}
 		}
 	}
-}
 
-#[cfg(test)]
-mod config_tests {
-	use super::*;
-
-	#[test]
-	fn parse_cmd_test() {
-		let tests: Vec<(&str, Vec<&str>)> = vec![
-			(r#"/bin/ls 'lol'"#, vec!["/bin/ls", "lol"]),
-			(r#"/bin/ls\ mdr"#, vec!["/bin/ls mdr"]),
-			(r#"/bin/ls '"lol'"#, vec!["/bin/ls", "\"lol"]),
-			(r#""'"\'"""#, vec![r#"''"#]),
-			// TODO: more tests
-		];
-		for test in tests {
-			assert_eq!(
-				parse_cmd(&test.0.to_string()),
-				test.1
-					.iter()
-					.map(|e| e.to_string())
-					.collect::<Vec<String>>()
-			)
-		}
+	pub fn dead_task(&self, pid: i32) {
+		let _tasks = self.tasks.lock().unwrap();
+		let mut _runnings = self.runnings.lock().unwrap();
+		println!("child died, pid: {}", pid);
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,12 @@
+use std::thread;
+use std::sync::{ Arc };
+
 mod task;
+mod parser;
+mod signals;
+use signals::{ create_sigset, signal_handler };
+
 mod config;
-mod exec;
 use config::Conf;
 
 type Error = Box<dyn std::error::Error>;
@@ -8,7 +14,15 @@ type Error = Box<dyn std::error::Error>;
 const CONFIGURATION: &str = "/home/tet/project/taskmaster/example.toml";
 
 fn main() -> Result<(), Error> {
-	let config: Conf = config::Conf::new(CONFIGURATION.to_string())?;
+	let config = Arc::new(Conf::new(CONFIGURATION.to_string())?);
 	config.autostart();
-	Ok(())
+
+	let sigset = create_sigset();
+	thread::spawn(move || {
+		let conf = Arc::clone(&config);
+		signal_handler(&sigset, &conf);
+	});
+	// signals
+	// from_client
+	loop { thread::sleep(std::time::Duration::from_secs(5));}
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,200 @@
+use std::fs;
+use std::sync::Mutex;
+use std::path::PathBuf;
+use libc::c_char;
+use serde_derive::Deserialize;
+
+use crate::Error;
+use crate::config::{ Conf };
+use crate::task::{ TaskConf };
+
+fn parse_cmd(entry: &String) -> Vec<String> {
+	let mut res = vec![];
+	let mut actual_string = String::new();
+	let mut dquote = false;
+	let mut squote = false;
+	let mut bslash = false;
+	let mut space = false;
+
+	for c in entry.chars() {
+		match c {
+			x if x == '\\' && !squote && !bslash => bslash = true,
+			x if x == '\\' && !dquote && !squote && bslash => { bslash = false; actual_string.push('\\'); }
+			x if x == '\'' && !squote && !dquote && !bslash => squote = true,
+			x if x == '\'' && squote => squote = false,
+			x if x == '"' && dquote && !bslash => dquote = false,
+			x if x == '"' && !dquote && !bslash && !squote => dquote = true,
+			x if !x.is_whitespace() && space => { space = false; res.push(actual_string); actual_string = x.to_string(); }
+			x if x.is_whitespace() && !dquote && !squote && !bslash => space = true,
+			x if x.is_whitespace() && bslash => { bslash = false; actual_string.push(x); }
+			x if (x == '\'' || x == '"' || x == '\\') && bslash => { bslash = false; actual_string.push(c); }
+			_ => { space = false; actual_string.push(c); }
+		}
+	}
+	if !actual_string.is_empty() {
+		res.push(actual_string);
+	}
+
+	if dquote || squote || bslash {
+		// TODO: log or exit because invalid command
+	}
+	res
+}
+
+#[derive(Deserialize, Debug)]
+struct EnvVar {
+	key: String,
+	value: String,
+}
+
+impl EnvVar {
+	fn to_string(self) -> String {
+		format!("{}={}", self.key, self.value)
+	}
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum MaybeArray<T> {
+	Alone(T),
+	Multiple(Vec<T>),
+}
+
+fn to_vec<T>(src: MaybeArray<T>) -> Vec<T> {
+	match src {
+		MaybeArray::Alone(n) => vec![n],
+		MaybeArray::Multiple(n) => n,
+	}
+}
+
+fn default_env() -> MaybeArray<EnvVar> { MaybeArray::Multiple(vec![]) }
+fn default_alone_zero() -> MaybeArray<i32> { MaybeArray::Alone(0) }
+fn default_autorestart() -> String { "false".to_string() }
+fn default_term() -> String { "TERM".to_string() }
+fn default_false() -> bool { false }
+fn default_umask() -> u32 { 777 }
+fn default_five() -> u32 { 5 }
+fn default_one() -> u32 { 1 }
+
+#[derive(Deserialize, Debug)]
+struct LitteralTasks {
+	cmd: String,
+	name: Option<String>,
+	#[serde(default = "default_one")]
+	numproc: u32,
+	#[serde(default = "default_umask")]
+	umask: u32,
+	workingdir: Option<String>,
+	#[serde(default = "default_false")]
+	autostart: bool,
+	#[serde(default = "default_autorestart")]
+	autorestart: String,
+	#[serde(default = "default_alone_zero")]
+	exitcodes: MaybeArray<i32>,
+	#[serde(default = "default_five")]
+	startretries: u32,
+	#[serde(default = "default_one")]
+	startime: u32,
+	#[serde(default = "default_term")]
+	stopsignal: String,
+	#[serde(default = "default_one")]
+	stoptime: u32,
+	stdout: Option<String>,
+	stderr: Option<String>,
+	#[serde(default = "default_env")]
+	env: MaybeArray<EnvVar>,
+}
+
+fn to_bytes(input: Vec<String>) -> Vec<Vec<c_char>> {
+	input
+		.into_iter()
+		.map(|e| {
+			let mut tmp = e.into_bytes();
+			tmp.push(b'\0');
+			tmp.iter().map(|b| *b as c_char).collect()
+		})
+		.collect()
+}
+
+impl LitteralTasks {
+	fn parse(self) -> TaskConf {
+		let handler = parse_cmd(&self.cmd);
+		let name = self.name.unwrap_or(handler[0].clone());
+		let args = to_bytes(handler);
+		let binary = args[0].clone();
+		let args = if args.len() == 0 { None } else { Some(args)};
+		let stdout = PathBuf::from(self.stdout.unwrap_or(format!("/tmp/{}.stdout", name)));
+		let stderr = PathBuf::from(self.stderr.unwrap_or(format!("/tmp/{}.stderr", name)));
+		TaskConf {
+			name,
+			binary,
+			args,
+			numproc: self.numproc,
+			umask: self.umask,
+			workingdir: self
+				.workingdir
+				.as_ref()
+				.and_then(|e| Some(PathBuf::from(e))),
+			autostart: self.autostart,
+			autorestart: self.autorestart.into(),
+			exitcodes: to_vec(self.exitcodes),
+			startretries: self.startretries,
+			startime: self.startime,
+			stopsignal: 9, // TODO: parse str into u32 or signal enum
+			stoptime: self.stoptime,
+			stdout,
+			stderr,
+			env: to_vec(self.env)
+				.into_iter()
+				.map(EnvVar::to_string)
+				.collect(),
+		}
+	}
+}
+
+#[derive(Deserialize, Debug)]
+struct LitteralConf {
+	port: Option<u32>,
+	tasks: Vec<LitteralTasks>,
+}
+
+impl LitteralConf {
+	fn parse(self) -> Conf {
+		Conf {
+			port: self.port.unwrap_or(6060),
+			tasks: Mutex::new(self.tasks.into_iter().map(LitteralTasks::parse).collect()),
+			runnings: Mutex::new(vec!())
+		}
+	}
+}
+
+pub fn parse_config(path: String) -> Result<Conf, Error> {
+	let file = fs::read_to_string(path)?;
+	let litteral_conf = toml::from_str::<LitteralConf>(&file)?;
+	Ok(litteral_conf.parse())
+}
+
+#[cfg(test)]
+mod config_tests {
+	use super::*;
+
+	#[test]
+	fn parse_cmd_test() {
+		let tests: Vec<(&str, Vec<&str>)> = vec![
+			(r#"/bin/ls 'lol'"#, vec!["/bin/ls", "lol"]),
+			(r#"/bin/ls\ mdr"#, vec!["/bin/ls mdr"]),
+			(r#"/bin/ls '"lol'"#, vec!["/bin/ls", "\"lol"]),
+			(r#""'"\'"""#, vec![r#"''"#]),
+			// TODO: more tests
+		];
+		for test in tests {
+			assert_eq!(
+				parse_cmd(&test.0.to_string()),
+				test.1
+					.iter()
+					.map(|e| e.to_string())
+					.collect::<Vec<String>>()
+			)
+		}
+	}
+}

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,0 +1,59 @@
+use std::{ mem, ptr };
+
+use crate::config::Conf;
+
+/*
+	Signals handling:
+		SIGCHILD: a child died
+		SIGHUP: reload conf
+		SIGTERM: kill all the childs
+*/
+
+pub type Sigset = libc::sigset_t;
+
+fn child_death(conf: &Conf) {
+	let mut status: libc::c_int = 0;
+	let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+	conf.dead_task(pid);
+}
+
+pub fn create_sigset() -> Sigset {
+	unsafe {
+		let mut set: libc::sigset_t = mem::zeroed();
+		if libc::sigemptyset(&mut set) == -1 {
+			unimplemented!("error handling");
+		}
+		if libc::sigaddset(&mut set, libc::SIGCHLD) == -1 {
+			unimplemented!("error handling");
+		}
+		if libc::sigaddset(&mut set, libc::SIGHUP) == -1 {
+			unimplemented!("error handling");
+		}
+		if libc::sigaddset(&mut set, libc::SIGTERM) == -1 {
+			unimplemented!("error handling");
+		}
+		let err = libc::pthread_sigmask(libc::SIG_BLOCK, &set, ptr::null_mut());
+		if err != 0 {
+			unimplemented!("error handling");
+		}
+		set
+	}
+}
+
+pub fn signal_handler(set: &Sigset, tasks: &Conf) {
+	let mut sig: libc::c_int = 0;
+	loop {
+		unsafe {
+			if libc::sigwait(set, &mut sig) != 0 {
+				unimplemented!("error handling")
+			}
+		}
+		match sig {
+			libc::SIGCHLD => child_death(tasks),
+			libc::SIGHUP => (),
+			libc::SIGTERM => (),
+			_ => ()
+		}
+		println!("got a signal: {}", sig);
+	}
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,12 +1,21 @@
+use std::path::PathBuf;
 use libc::c_char;
 use libc::execve;
 use libc::fork;
 use libc::INT_MAX;
-use std::path::PathBuf;
 
 #[allow(dead_code)]
-pub struct RunnigTask {
+#[derive(Debug)]
+pub struct RunningTask {
 	// TODO
+}
+
+// name should be task name + identifier
+impl RunningTask {
+	pub fn new(_name: &str, _task_name: &str, pid: i32) -> Self {
+		println!("new task, pid: {}", pid);
+		RunningTask {}
+	}
 }
 
 // TODO: signal enum
@@ -50,19 +59,18 @@ pub struct TaskConf {
 }
 
 impl TaskConf {
-	pub fn run(&self) {
-		unsafe {
-			match fork() {
-				pid if pid > 0 && pid < INT_MAX => println!("Child PID: {}", pid),
-				_ => {
-					let mut args = match &self.args {
-						Some(a) => a.iter().map(|e| e.as_ptr()).collect(),
-						None => Vec::new(),
-					};
-					args.push(std::ptr::null());
-					execve(self.binary.as_ptr() as *const i8, args.as_ptr() as *const *const i8, std::ptr::null());
-				}
-			};
+	pub fn run(&self) -> i32 { // TODO: handle errors
+		match unsafe { fork() } {
+			pid if pid > 0 && pid < INT_MAX => pid,
+			_ => {
+				let mut args = match &self.args {
+					Some(a) => a.iter().map(|e| e.as_ptr()).collect(),
+					None => Vec::new(),
+				};
+				args.push(std::ptr::null());
+				unsafe { execve(self.binary.as_ptr() as *const i8, args.as_ptr() as *const *const i8, std::ptr::null()); }
+				0 // Will not be executed
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Fix #5 
Handler for the death of a child, recover his pid.

Provide a threadsafe interface for `Conf` with the beginning of some methods.

Move the parsings `fn`/`struct` into  `parsing.rs`.