### PR TITLE
Set child options: init signals, chdir, umask, and stdout and stderr …

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use config::Conf;
 
 type Error = Box<dyn std::error::Error>;
 
-const CONFIGURATION: &str = "/home/tet/project/taskmaster/example.toml";
+const CONFIGURATION: &str = "/Users/cedricmpassi/Programming/42/taskmaster/ls.toml";
 
 fn main() -> Result<(), Error> {
 	let config = Arc::new(Conf::new(CONFIGURATION.to_string())?);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,7 +72,7 @@ fn default_alone_zero() -> MaybeArray<i32> { MaybeArray::Alone(0) }
 fn default_autorestart() -> String { "false".to_string() }
 fn default_term() -> String { "TERM".to_string() }
 fn default_false() -> bool { false }
-fn default_umask() -> u32 { 777 }
+fn default_umask() -> u16 { 777 }
 fn default_five() -> u32 { 5 }
 fn default_one() -> u32 { 1 }
 
@@ -83,7 +83,7 @@ struct LitteralTasks {
 	#[serde(default = "default_one")]
 	numproc: u32,
 	#[serde(default = "default_umask")]
-	umask: u32,
+	umask: u16,
 	workingdir: Option<String>,
 	#[serde(default = "default_false")]
 	autostart: bool,

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,6 +1,16 @@
 use std::path::PathBuf;
+use std::env::set_current_dir;
+use std::fs::OpenOptions;
+use std::fs::File;
 use libc::c_char;
 use libc::execve;
+use libc::dup2;
+use libc::STDOUT_FILENO;
+use libc::STDERR_FILENO;
+use libc::umask;
+use libc::signal;
+use libc::SIG_DFL;
+use std::os::unix::io::IntoRawFd;
 use libc::fork;
 use libc::INT_MAX;
 
@@ -44,8 +54,8 @@ pub struct TaskConf {
 	pub binary: Vec<c_char>,
 	pub args: Option<Vec<Vec<c_char>>>,
 	pub numproc: u32,
-	pub umask: u32,
-	pub workingdir: Option<PathBuf>, // env::set_current_dir
+	pub umask: u16,
+	pub workingdir: Option<PathBuf>,
 	pub autostart: bool,
 	pub autorestart: Autorestart,
 	pub exitcodes: Vec<i32>,
@@ -58,17 +68,37 @@ pub struct TaskConf {
 	pub env: Vec<String>,
 }
 
+fn reset_signals() {
+    let nb_signals: i32 = 39;
+    for n in 1..nb_signals {
+        unsafe { signal(n, SIG_DFL); }
+    }
+}
+
 impl TaskConf {
 	pub fn run(&self) -> i32 { // TODO: handle errors
 		match unsafe { fork() } {
 			pid if pid > 0 && pid < INT_MAX => pid,
 			_ => {
+                                let stdout: File = OpenOptions::new().write(true).truncate(true).create(true).open(&self.stdout.as_path()).unwrap();
+                                let stderr: File = OpenOptions::new().write(true).truncate(true).create(true).open(&self.stderr.as_path()).unwrap();
 				let mut args = match &self.args {
 					Some(a) => a.iter().map(|e| e.as_ptr()).collect(),
 					None => Vec::new(),
 				};
 				args.push(std::ptr::null());
-				unsafe { execve(self.binary.as_ptr() as *const i8, args.as_ptr() as *const *const i8, std::ptr::null()); }
+                                dbg!(&self);
+                                match &self.workingdir {
+                                    Some(x) =>  set_current_dir(x).is_ok(),
+                                    None => false // error Handling
+                                };
+				unsafe { 
+                                    reset_signals();
+                                    umask(self.umask);
+                                    dup2(stdout.into_raw_fd(), STDOUT_FILENO);  
+                                    dup2(stderr.into_raw_fd(), STDERR_FILENO); 
+                                    execve(self.binary.as_ptr() as *const i8, args.as_ptr() as *const *const i8, std::ptr::null()); 
+                                }
 				0 // Will not be executed
 			}
 		}


### PR DESCRIPTION
Implementation des options pour le lancement des process, avec la réinitialisation des signaux.

closes #9 